### PR TITLE
Fix failing grayscale image generation

### DIFF
--- a/fauxtograph/fauxto.py
+++ b/fauxtograph/fauxto.py
@@ -150,7 +150,7 @@ def generate(model_path, img_dir, number, extremity, mean, format, image_multipl
     for i in range(number):
         im = reconstructed[i]
         im = np.clip(image_multiplier*im/im.max(), 0, 255)
-        im = Image.fromarray(np.uint8(reconstructed[i]))
+        im = Image.fromarray(np.uint8(np.squeeze(im)))
         fname = "{0}.{1}".format(i, format)
         path = os.path.join(img_dir, fname)
         im.save(path)

--- a/fauxtograph/fauxtograph.py
+++ b/fauxtograph/fauxtograph.py
@@ -327,7 +327,7 @@ class ImageAutoEncoder():
         '''
         encoded = chainer.Variable(encoded)
         output = self._decode(encoded)
-        return output.data.reshape((-1, self.img_height, self.img_width, 3))
+        return output.data.reshape((-1, self.img_height, self.img_width, self.color_channels))
 
     def dump(self, filepath):
         '''Saves model as a sequence of files.


### PR DESCRIPTION
While it is possible to train on grayscale images, one cannot use the trained model to generate grayscale images.