### PR TITLE
turned down default command-line kl_ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ fauxtograph download ./images
 
 Then you can train a model and output it to disk with 
 ```bash
-$ fauxtograph train ./images ./models/model_name 
+$ fauxtograph train --kl_ratio 0.005 ./images ./models/model_name 
 ```
 
 Finally, you can generate new images based on your trained model with


### PR DESCRIPTION
Dropped the default kl_ratio from 1.0 to 0.005. Note that
this change was only made to the command line default, not
to the VAE class initializer. With this change, the downloaded
hubble dataset produces reasonable images that don't all
look the same when fauxtograph train is run with 
default parameters.

Fixes #10 

Sample run below

```bash
fauxtograph train --gpu ./images ./models/hubble
fauxtograph generate ./models/hubble_model.h5 ./models/hubble_opt.h5 ./models/hubble_meta.json ./images_hubble
```

![0](https://cloud.githubusercontent.com/assets/945979/12509248/ea1003cc-c0b5-11e5-8535-64a3b70c2395.jpg)
![1](https://cloud.githubusercontent.com/assets/945979/12509251/ea129330-c0b5-11e5-9bfc-636fea1e9845.jpg)
![2](https://cloud.githubusercontent.com/assets/945979/12509250/ea1260ae-c0b5-11e5-8db6-ea73bfd4add3.jpg)
![3](https://cloud.githubusercontent.com/assets/945979/12509253/ea175e7e-c0b5-11e5-924b-f28c6a6ed861.jpg)
![4](https://cloud.githubusercontent.com/assets/945979/12509252/ea13a806-c0b5-11e5-910e-f0500cd56864.jpg)
![5](https://cloud.githubusercontent.com/assets/945979/12509249/ea11bbe0-c0b5-11e5-98a1-64bba261a88c.jpg)
![6](https://cloud.githubusercontent.com/assets/945979/12509254/ea2342a2-c0b5-11e5-8c25-731193d2da22.jpg)
![7](https://cloud.githubusercontent.com/assets/945979/12509257/ea2b3782-c0b5-11e5-9bd7-7aa60ba1adf8.jpg)
![8](https://cloud.githubusercontent.com/assets/945979/12509255/ea2596b0-c0b5-11e5-848c-f09777891e10.jpg)
![9](https://cloud.githubusercontent.com/assets/945979/12509256/ea27f90a-c0b5-11e5-8f71-7edc0ab0c5e3.jpg)

