### PR TITLE
Python3 compatibility

### DIFF
--- a/fauxtograph/fauxto.py
+++ b/fauxtograph/fauxto.py
@@ -1,6 +1,6 @@
 import click
 from fauxtograph import VAE, image_resize, get_paths
-from BeautifulSoup import BeautifulSoup
+from bs4 import BeautifulSoup
 import requests as r
 import os
 import numpy as np

--- a/fauxtograph/fauxto.py
+++ b/fauxtograph/fauxto.py
@@ -49,7 +49,7 @@ def download_page(filepath, url, pic_type, page):
             img = img_data.content
             numb_str = '{0}{1}_{2}.jpg'.format(pic_type, page, i)
             path = os.path.join(filepath, numb_str)
-            with open(path, 'w') as f:
+            with open(path, 'wb') as f:
                 f.write(img)
 
 

--- a/fauxtograph/fauxtograph.py
+++ b/fauxtograph/fauxtograph.py
@@ -1,16 +1,19 @@
+from __future__ import absolute_import  # For Python 2/3 compatibility
+
 from PIL import Image
 import chainer.functions as F
 from chainer import Variable
 import chainer.optimizers as O
 from chainer import serializers
 import matplotlib.pyplot as plt
-from vaegan import *
+from .vaegan import *
 import tqdm
 import time
 import numpy as np
 import os
 from IPython.display import display
 import json
+from functools import reduce
 
 
 class VAE(object):
@@ -118,7 +121,7 @@ class VAE(object):
         d.pop('opt')
         # d.pop('xp')
         meta = json.dumps(d)
-        with open(filepath+'.json', 'wb') as f:
+        with open(filepath+'.json', 'w') as f:
             f.write(meta)
 
     def transform(self, data, test=False):

--- a/fauxtograph/vaegan.py
+++ b/fauxtograph/vaegan.py
@@ -3,6 +3,7 @@ import chainer.links as L
 from chainer import Variable
 import chainer
 import numpy as np
+from functools import reduce
 
 
 class Encoder(chainer.Chain):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ beautifulsoup4==4.4.1
 chainer==1.6.0
 click==5.1
 decorator==4.0.2
-fauxtograph==0.2.0
 funcsigs==0.4
 gnureadline==6.3.3
 ipython==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 appnope==0.1.0
-BeautifulSoup==3.2.1
+beautifulsoup4==4.4.1
 chainer==1.6.0
 click==5.1
 decorator==4.0.2

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'numpy',
         'click>=5.0',
         'matplotlib',
+        'jupyter',
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='fauxtograph',
-    version='1.0.3',
+    version='1.0.4',
     author='TJ Torres',
     author_email='ttorres@mit.edu',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'pillow',
         'joblib',
         'tqdm',
-        'BeautifulSoup',
+        'beautifulsoup4',
         'requests',
         'numpy',
         'click>=5.0',


### PR DESCRIPTION
I encountered several bugs running it on Python 3. I fixed them here in a way compatible with both Python 2 and 3 so everyone's happy. This PR includes:
- Use BeautifulSoup 4 instead of the obsolete version 3
- Fix for relative import, which is not the default in py3.
- Import the reduce() because it's not a builtin funciton in py3.
- Fixing saving files (string vs bytes).

This update was tested on Python 2.7 and 3.5 on OSX.
